### PR TITLE
REFACTOR: simplify the custom bindings of `nushell`

### DIFF
--- a/.config/nushell/lib/core/keybindings.nu
+++ b/.config/nushell/lib/core/keybindings.nu
@@ -23,39 +23,29 @@ export alias keybindings = [
     modifier: control
     keycode: char_r
     mode: [ emacs vi_insert vi_normal ]
-    event: [
-      { edit: clear }
-      {
-        edit: insertString
-        value: $"source ($nu.env-path); source ($nu.config-path)"
-      }
-      { send: Enter }
-    ]
+    event: {
+      send: executehostcommand,
+      cmd: $"source ($nu.env-path); source ($nu.config-path)"
+    }
   }
   {
     name: open_repo
     modifier: control
     keycode: char_g
     mode: [emacs, vi_insert, vi_normal]
-    event: [
-      {
-        edit: insertString
-        value: "repo goto"
-      }
-      { send: Enter }
-    ]
+    event: {
+      send: executehostcommand
+      cmd: "repo goto"
+    }
   }
   {
     name: edit_config
     modifier: control
     keycode: char_v
     mode: [emacs, vi_insert, vi_normal]
-    event: [
-      {
-        edit: insertString
-        value: "dotfiles edit"
-      }
-      { send: Enter }
-    ]
+    event: {
+      send: executehostcommand
+      cmd: "dotfiles edit"
+    }
   }
 ]


### PR DESCRIPTION
Related to #39.

This PR simplifies the `nushell` bindings, making them easier to read and better, e.g. `repo goto` won't show on the terminal and won't be part of the history of commands when pressing `C-g`, which is cool :+1: 