### PR TITLE
FEATURE: add `ls | grid` as alias and hook to `nushell`

### DIFF
--- a/.config/nushell/lib/core/hooks.nu
+++ b/.config/nushell/lib/core/hooks.nu
@@ -18,7 +18,7 @@ export alias hooks = {
   }]
   env_change: {
     PWD: [{|before, after|
-      $nothing  # replace with source code to run if the PWD environment is different since the last repl input
+      print (ls | sort-by type name -i | grid -c | str trim)  # replace with source code to run if the PWD environment is different since the last repl input
     }]
   }
 }

--- a/.config/nushell/lib/personal/aliases.nu
+++ b/.config/nushell/lib/personal/aliases.nu
@@ -15,3 +15,4 @@ alias mv = mv --verbose
 alias cb = ^cbonsai --infinite --live --base=1 --wait=2 --time=10
 
 alias sl = sl -aw -20
+alias lsg = (ls | sort-by type name -i | grid -c | str trim)


### PR DESCRIPTION
Related to #39.

This PR adds `ls | ... | grid -c` as an alias as `lsg` and triggers it when changing directory to have an overview of the new `pwd`.