### PR TITLE
FEATURE: add the downloads directory to the environment of `nushell`.

### DIFF
--- a/.config/nushell/env.nu
+++ b/.config/nushell/env.nu
@@ -264,6 +264,8 @@ let-env QUICKEMU_HOME = ($env.XDG_DATA_HOME | path join "quickemu")
 let-env DOTFILES_GIT_DIR = ($env.GHQ_ROOT| path join "github.com" "goatfiles" "dotfiles")
 let-env DOTFILES_WORKTREE = $env.HOME
 
+let-env DOWNLOADS_DIR = ("~/downloads" | path expand)
+
 let-env FZF_DEFAULT_OPTS = "
 --bind ctrl-d:half-page-down
 --bind ctrl-u:half-page-up


### PR DESCRIPTION
Related to #39.

This PR adds the `~/downloads/` directory to the `$env` of `nushell`.