### PR TITLE
FEATURE: use `vivid` to set the colors of `ls` in `nushell`.

### DIFF
--- a/.config/nushell/env.nu
+++ b/.config/nushell/env.nu
@@ -289,3 +289,6 @@ let-env LD_LIBRARY_PATH = ($env.LD_LIBRARY_PATH | split row (char esep) |
 #
 let-env USE_FINAL_CONFIG_HOOK = false
 let-env QT_QPA_PLATFORMTHEME = "qt5ct"
+
+let-env LS_THEME = "dracula"
+let-env LS_COLORS = (vivid generate $env.LS_THEME)


### PR DESCRIPTION
Related to #39.

This PR uses `vivid` to set the `LS_COLORS` in `nushell`, changing the theme with only `LS_THEME` in `env.nu`.