### PR TITLE
FIX: use `... | path exists` in `nushell` to test files and directories.

### DIFF
--- a/.config/nushell/lib/applications/venv.nu
+++ b/.config/nushell/lib/applications/venv.nu
@@ -26,7 +26,7 @@ export def new [
     print -n $"venv new: (ansi red)error(ansi reset): "
     $"venv should be one directory inside ($env.VIRTUALENVWRAPPER_HOOK_DIR)"
   } else {
-    if ((do -i {^ls $venv} | complete | get exit_code) != 0) {
+    if not ($venv | path exists) {
       virtualenv $venv
     } else {
       print -n $"venv new: (ansi red)error(ansi reset): "

--- a/.config/nushell/lib/applications/vm.nu
+++ b/.config/nushell/lib/applications/vm.nu
@@ -42,11 +42,7 @@ export def pull [] {
     let os = $choice
     let vm_directory = ($env.QUICKEMU_HOME | path join $os)
 
-    if (
-        (do -i {^ls $vm_directory} |
-        complete |
-        get exit_code) != 0
-    ) {
+    if not ($vm_directory | path exists) {
         mkdir $vm_directory
     }
 


### PR DESCRIPTION
Related to #39.

This PR uses the better `path exists` command in the scripts, instead of `do -i { ... } | complete | get exit_code`.