### PR TITLE
FEATURE: make the aliases available to all the `nushell` config

### DIFF
--- a/.config/nushell/config.nu
+++ b/.config/nushell/config.nu
@@ -11,6 +11,8 @@
 
 # base up-to-date with Nushell version 0.67.0
 
+source personal/aliases.nu
+
 use core/completions.nu *
 use core/themes.nu
 use core/hooks.nu *
@@ -88,8 +90,6 @@ let-env config = {
   keybindings: (keybindings)
 }
 
-
-source personal/aliases.nu
 
 use scripts/misc.nu *
 use scripts/community.nu *

--- a/.config/nushell/lib/core/hooks.nu
+++ b/.config/nushell/lib/core/hooks.nu
@@ -18,7 +18,7 @@ export alias hooks = {
   }]
   env_change: {
     PWD: [{|before, after|
-      print (ls | sort-by type name -i | grid -c | str trim)  # replace with source code to run if the PWD environment is different since the last repl input
+      print (lsg)  # replace with source code to run if the PWD environment is different since the last repl input
     }]
   }
 }


### PR DESCRIPTION
Related to #39.

This PR moves the aliases to the top of the `config.nu` imports, making the aliases available to all the config, e.g. `lsg` in the hooks` :yum: