### PR TITLE
FEATURE: pull, source and overwrite the default config of `nushell` with custom values

### DIFF
--- a/.config/nushell/config.nu
+++ b/.config/nushell/config.nu
@@ -13,83 +13,36 @@
 
 source personal/aliases.nu
 
+source default_config.nu
+
 use core/completions.nu *
 use core/themes.nu
 use core/hooks.nu *
 use core/menus.nu *
 use core/keybindings.nu *
 
-# The default config record. This is where much of your global configuration is setup.
-let-env config = {
+let custom_config = {
   ls: {
-    use_ls_colors: true # use the LS_COLORS environment variable to colorize output
-    clickable_links: false # enable or disable clickable links. Your terminal has to support links.
+    use_ls_colors: true
+    clickable_links: false
   }
   rm: {
-    always_trash: false # always act as if -t was given. Can be overridden with -p
+    always_trash: true
   }
   cd: {
-    abbreviations: true # allows `cd s/o/f` to expand to `cd some/other/folder`
+    abbreviations: true
   }
-  table: {
-    mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
-    index_mode: always # "always" show indexes, "never" show indexes, "auto" = show indexes when a table has "index" column
-    trim: {
-      methodology: wrapping # wrapping or truncating
-      wrapping_try_keep_words: true # A strategy used by the 'wrapping' methodology
-      truncating_suffix: "..." # A suffix used by the 'truncating' methodology
-    }
-  }
-  explore: {
-    highlight: { bg: 'yellow', fg: 'black' }
-    status_bar: { bg: '#C4C9C6', fg: '#1D1F21' }
-    command_bar: { fg: '#C4C9C6' }
-    split_line: '#404040'
-    cursor: true
-    # selected_column: 'blue'
-    # selected_row: { fg: 'yellow', bg: '#C1C2A3' }
-    # selected_cell: { fg: 'white', bg: '#777777' }
-    # line_shift: false,
-    # line_index: false,
-    # line_head_top: false,
-    # line_head_bottom: false,
-  }
-  history: {
-    max_size: 10000 # Session has to be reloaded for this to take effect
-    sync_on_enter: true # Enable to share history between multiple sessions, else you have to close the session to write history to file
-    file_format: "plaintext" # "sqlite" or "plaintext"
-  }
-  completions: {
-    case_sensitive: false # set to true to enable case-sensitive completions
-    quick: true  # set this to false to prevent auto-selecting completions when only one remains
-    partial: true  # set this to false to prevent partial filling of the prompt
-    algorithm: "prefix"  # prefix or fuzzy
-    external: {
-      enable: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up my be very slow
-      max_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
-      completer: null # check 'carapace_completer' above as an example
-    }
-  }
-  filesize: {
-    metric: true # true => KB, MB, GB (ISO standard), false => KiB, MiB, GiB (Windows standard)
-    format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
-  }
-  color_config: (themes base16) # if you want a light theme, replace `(themes dark)` to `(themes light)`
-  use_grid_icons: true
-  footer_mode: "25" # always, never, number_of_rows, auto
-  float_precision: 2
-  #buffer_editor: "helix" # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
-  use_ansi_coloring: true
-  edit_mode: vi # emacs, vi
-  shell_integration: true # enables terminal markers and a workaround to arrow keys stop working issue
-  show_banner: false # true or false to enable or disable the banner
-  render_right_prompt_on_last_line: false # true or false to enable or disable right prompt to be rendered on last line of the prompt
+
+  color_config: (themes base16)
+
+  edit_mode: vi
+  show_banner: false
 
   hooks: (hooks)
   menus: (menus)
   keybindings: (keybindings)
 }
-
+let-env config = ($env.config | merge $custom_config)
 
 use scripts/misc.nu *
 use scripts/community.nu *

--- a/.config/nushell/env.nu
+++ b/.config/nushell/env.nu
@@ -199,6 +199,38 @@ let-env DEFAULT_CONFIG_FILE = (
   | path join "default_config.nu"
 )
 
+
+# TODO
+# credit to @kubouch
+# https://discord.com/channels/601130461678272522/1050117978403917834/1051457787663761518
+export def "config update default" [ --help (-h) ] {
+  let name = ($env.DEFAULT_CONFIG_FILE | path basename)
+  let default_url = (
+    [
+        'https://raw.githubusercontent.com'
+        'nushell/nushell/main/crates/nu-utils/src/sample_config'
+        $name
+    ]
+    | path join
+  )
+
+  if ($env.DEFAULT_CONFIG_FILE| path expand | path exists) {
+    let new = (fetch $default_url)
+    let old = (open $env.DEFAULT_CONFIG_FILE)
+
+    if $old != $new {
+      $new | save --raw $env.DEFAULT_CONFIG_FILE
+      print $'Updated ($name)'
+    } else {
+      print $'($name): No change'
+    }
+  } else {
+    fetch $default_url | save --raw $env.DEFAULT_CONFIG_FILE
+    print $'Downloaded new ($name)'
+  }
+}
+
+
 # Directories to search for plugin binaries when calling register
 #
 # By default, <nushell-config-dir>/plugins is added

--- a/.config/nushell/env.nu
+++ b/.config/nushell/env.nu
@@ -194,6 +194,11 @@ let-env NU_LIB_DIRS = [
     ($nu.config-path | path dirname | path join 'lib')
 ]
 
+let-env DEFAULT_CONFIG_FILE = (
+  $env.NU_LIB_DIRS.0
+  | path join "default_config.nu"
+)
+
 # Directories to search for plugin binaries when calling register
 #
 # By default, <nushell-config-dir>/plugins is added


### PR DESCRIPTION
Related to #39.


This PR
- adds a script, `config update default` to the `env.nu` config file to pull the [default config](https://raw.githubusercontent.com/nushell/nushell/main/crates/nu-utils/src/sample_config/default_config.nu) of `nushell` and put it inside the `NU_LIB_DIRS.0` directory
- source this file in `config.nu`
- overwrite custom values with `merge`