### PR TITLE
FEATURE: add miscellaneous updates to `nushell`

### DIFF
--- a/.config/nushell/config.nu
+++ b/.config/nushell/config.nu
@@ -26,7 +26,7 @@ let-env config = {
     clickable_links: false # enable or disable clickable links. Your terminal has to support links.
   }
   rm: {
-    always_trash: false # always act as if -t was given. Can be overridden with -p
+    always_trash: true # always act as if -t was given. Can be overridden with -p
   }
   cd: {
     abbreviations: true # allows `cd s/o/f` to expand to `cd some/other/folder`

--- a/.config/nushell/env.nu
+++ b/.config/nushell/env.nu
@@ -293,5 +293,7 @@ let-env LD_LIBRARY_PATH = ($env.LD_LIBRARY_PATH | split row (char esep) |
 let-env USE_FINAL_CONFIG_HOOK = false
 let-env QT_QPA_PLATFORMTHEME = "qt5ct"
 
+let-env TOMB_HOME = ($env.XDG_DATA_HOME | path join "tombs")
+
 let-env LS_THEME = "dracula"
 let-env LS_COLORS = (vivid generate $env.LS_THEME)

--- a/.config/nushell/env.nu
+++ b/.config/nushell/env.nu
@@ -277,10 +277,11 @@ let-env FZF_DEFAULT_OPTS = "
 
 # To add entries to PATH (on Windows you might use Path), you can use the following pattern:
 # let-env PATH = ($env.PATH | split row (char esep) | prepend '/some/path')
-let-env PATH = ($env.PATH | split row (char esep) |
-    prepend ($env.HOME | path join ".local" "bin") |
-    prepend ($env.EMACS_HOME | path join "bin") |
-    prepend ($env.CARGO_HOME | path join "bin")
+let-env PATH = ($env.PATH | split row (char esep)
+    | prepend ($env.HOME | path join ".local" "bin")
+    | prepend ($env.EMACS_HOME | path join "bin")
+    | prepend ($env.CARGO_HOME | path join "bin")
+    | prepend ($env.XDG_DATA_HOME | path join "clang-15" "bin")
 )
 let-env LD_LIBRARY_PATH = ($env.LD_LIBRARY_PATH | split row (char esep) |
     prepend $env.MUJOCO_BIN

--- a/.config/nushell/lib/applications/dotfiles.nu
+++ b/.config/nushell/lib/applications/dotfiles.nu
@@ -2,6 +2,7 @@ use applications/prompt.nu
 
 alias GIT = ^git --git-dir $env.DOTFILES_GIT_DIR --work-tree $env.DOTFILES_WORKTREE
 
+alias FZF_EDIT_PREVIEW = "bat $HOME/{} --color always"
 
 # TODO
 export def-env edit [] {
@@ -17,7 +18,7 @@ export def-env edit [] {
     #
     let choice = (
         GIT lf --full-name ~ |
-        prompt fzf_ask "Please choose a config file to edit: "
+        prompt fzf_ask "Please choose a config file to edit: " (FZF_EDIT_PREVIEW)
     )
 
     let path = ($env.HOME | path join $choice)

--- a/.config/nushell/lib/applications/prompt.nu
+++ b/.config/nushell/lib/applications/prompt.nu
@@ -4,11 +4,12 @@ use applications/context.nu
 # TODO
 export def fzf_ask [
     prompt: string
+    preview: string = ""
 ] {
     let choice = (
         $in |
         to text |
-        fzf --prompt $prompt --ansi |
+        fzf --prompt $prompt --ansi --color --preview $preview |
         str trim
     )
 

--- a/.config/nushell/lib/applications/repo.nu
+++ b/.config/nushell/lib/applications/repo.nu
@@ -34,7 +34,9 @@ def pick_repo [
 
 
 # TODO
-export def-env goto [] {
+export def-env goto [
+    --clear (-c): bool  # TODO
+] {
     # jump to any repo registered with ghq.
     #
     # the function will:
@@ -54,6 +56,10 @@ export def-env goto [] {
            | path join $choice
         )
     cd $path
+
+    if ($clear) {
+        clear
+    }
 }
 
 

--- a/.config/nushell/lib/applications/repo.nu
+++ b/.config/nushell/lib/applications/repo.nu
@@ -95,5 +95,5 @@ export def remove [] {
 
     let path = ($env.GHQ_ROOT | path join $repo)
 
-    rm --interactive --recursive $path
+    rm --trash --interactive --recursive $path
 }

--- a/.config/nushell/lib/applications/repo.nu
+++ b/.config/nushell/lib/applications/repo.nu
@@ -1,5 +1,20 @@
 use applications/prompt.nu
 
+alias FZF_PICK_PREVIEW = "
+path=$(ghq root)/$(echo {} | sed 's/: /.com\\//')
+echo "TREE:"
+git -C $path --no-pager log --graph --branches --remotes --tags --oneline --decorate --simplify-by-decoration -n 10 --color=always
+echo ""
+echo "STATUS:"
+git -C $path --no-pager status --short
+echo ""
+echo "STASHES:"
+git -C $path --no-pager stash list
+echo ""
+echo "FILES:"
+ls -la --color=always $path | awk '{print $1,$9}'
+"
+
 
 # TODO
 def pick_repo [
@@ -10,7 +25,7 @@ def pick_repo [
         lines |
         str replace ".com/" ": " |
         sort --ignore-case |
-        prompt fzf_ask $prompt |
+        prompt fzf_ask $prompt (FZF_PICK_PREVIEW) |
         str replace ": " ".com/"
     )
 
@@ -39,34 +54,6 @@ export def-env goto [] {
            | path join $choice
         )
     cd $path
-
-    # print a little message.
-    print $"Jumping to ($path)"
-
-    # the content of the repo.
-    print "\nCONTENT:"
-    ls
-
-    # the status of the repo, in short format,
-    # if anything to report.
-    if not (^git status --short | is-empty) {
-        print "\nSTATUS:"
-        ^git --no-pager status --short
-    } else {
-        print "\nEVERYTHING UP TO DATE!"
-    }
-
-    # the list of stashes, if any.
-    if not (^git stash list | is-empty) {
-        print "\nSTASHES:"
-        ^git --no-pager stash list
-    } else {
-        print "\nNO STASH..."
-    }
-
-    # the current tree in compact form.
-    print "\nLOG:"
-    ^git --no-pager log --graph --branches --remotes --tags --oneline --decorate --simplify-by-decoration -n 10
 }
 
 

--- a/.config/nushell/lib/applications/repo.nu
+++ b/.config/nushell/lib/applications/repo.nu
@@ -80,7 +80,7 @@ export def pull [
         get name |
         sort --ignore-case |
         uniq |
-        prompt fzf_ask $"Please choose a repo to pull from https://github.com/($owner)"
+        prompt fzf_ask $"Please choose a repo to pull from https://github.com/($owner): "
     )
 
     let repository = ([$owner $choice] | str collect "/")

--- a/.config/nushell/lib/applications/venv.nu
+++ b/.config/nushell/lib/applications/venv.nu
@@ -59,5 +59,5 @@ export def remove [] {
 
   let path = ($env.VIRTUALENVWRAPPER_HOOK_DIR | path join $venv)
 
-  rm --interactive --recursive $path
+  rm --trash --interactive --recursive $path
 }

--- a/.config/nushell/lib/applications/vm.nu
+++ b/.config/nushell/lib/applications/vm.nu
@@ -91,8 +91,8 @@ export def remove [] {
     let os = ($vm | split column "-" | get column1 | to text)
     let path = ($env.QUICKEMU_HOME | path join $os $vm)
 
-    rm -rvfi $path
-    rm -rvfi $"($path).conf"
+    rm --trash -rvfi $path
+    rm --trash -rvfi $"($path).conf"
 }
 
 

--- a/.config/nushell/lib/core/keybindings.nu
+++ b/.config/nushell/lib/core/keybindings.nu
@@ -48,4 +48,14 @@ export alias keybindings = [
       cmd: "dotfiles edit"
     }
   }
+  {
+    name: clear_and_ls
+    modifier: control
+    keycode: char_l
+    mode: [emacs, vi_normal, vi_insert]
+    event: {
+      send: executehostcommand
+      cmd: "clear; lsg"
+    }
+  }
 ]

--- a/.config/nushell/lib/core/keybindings.nu
+++ b/.config/nushell/lib/core/keybindings.nu
@@ -35,7 +35,7 @@ export alias keybindings = [
     mode: [emacs, vi_insert, vi_normal]
     event: {
       send: executehostcommand
-      cmd: "repo goto"
+      cmd: "repo goto --clear"
     }
   }
   {

--- a/.config/nushell/lib/personal/aliases.nu
+++ b/.config/nushell/lib/personal/aliases.nu
@@ -8,7 +8,7 @@ alias q = exit
 
 # be more verbose
 alias cp = cp --verbose
-alias rm = rm --verbose
+alias rm = rm --trash --verbose
 alias mv = mv --verbose
 
 # misc

--- a/.config/nushell/lib/scripts/community.nu
+++ b/.config/nushell/lib/scripts/community.nu
@@ -97,3 +97,39 @@ def mvr [
 ] {
   mv $path ($moveto | str replace % ($path | path dirname))
 }
+
+
+# TODO
+# credit to @Eldyj
+# https://discord.com/channels/601130461678272522/615253963645911060/1048654339494912031
+export def "cross pathsep" [] {
+  if ($nu.os-info.name =~ windows) {
+    "\\"
+  } else {
+    "/"
+  }
+}
+
+
+# TODO
+# credit to @Eldyj
+# https://discord.com/channels/601130461678272522/615253963645911060/1048654339494912031
+export def "cross home" [] {
+  if ($nu.os-info.name =~ windows) {
+    $env.USERPROFILE
+  } else {
+    $env.HOME
+  }
+}
+
+
+# TODO
+# credit to @Eldyj
+# https://discord.com/channels/601130461678272522/615253963645911060/1048654339494912031
+export def "cross username" [] {
+  if ($nu.os-info.name =~ windows) {
+    $env.USERNAME
+  } else {
+    $env.USER
+  }
+}

--- a/.config/nushell/lib/scripts/community.nu
+++ b/.config/nushell/lib/scripts/community.nu
@@ -69,7 +69,7 @@ export def-env br [args = "."] {
     let cmd_file = (^mktemp | str trim);
     ^broot --outcmd $cmd_file $args;
     let cmd = ((open $cmd_file) | str trim);
-    ^rm $cmd_file;
+    ^rm --trash $cmd_file;
     cd ($cmd | str replace "cd" "" | str trim)
 }
 


### PR DESCRIPTION
Related to #39.

This PR:
- activates the trash
- use `--trash` on all the `rm`s in the scripts
- use the `|` pipe symbol at the beginning of the lines in the `PATH` declaration
- add `TOMB_HOME` to the environment
- add previews to `fzf` directly for `repo goto` and `dotfiles edit`, instead of showing them afterwards
- add `--clear` to `repo goto`
- make `C-l` clear the terminal and run `lsg` to show the content of the directory
- add some cross-platform functions from the discord server