### PR TITLE
NEW: add config for `gdb`

### DIFF
--- a/.config/gdb/gdbinit
+++ b/.config/gdb/gdbinit
@@ -1,0 +1,1 @@
+set debuginfod enabled off


### PR DESCRIPTION
This PR adds a basic config for `gdb`, i.e. not pulling the debuginfo.