### PR TITLE
FIX: remove `dtos-core-repo` from pacman, it's broken

### DIFF
--- a/.system/etc/pacman.conf
+++ b/.system/etc/pacman.conf
@@ -111,7 +111,3 @@ Include = /etc/pacman.d/mirrorlist
 #[custom]
 #SigLevel = Optional TrustAll
 #Server = file:///home/custompkgs
-
-[dtos-core-repo]
-SigLevel = Required DatabaseOptional
-Server = https://gitlab.com/dtos/$repo/-/raw/main/$arch


### PR DESCRIPTION
This PR simply removes the broken `dtos-core-repo` library from `pacman`.