### PR TITLE
FIX: use `VISUAL=EDITOR` and not `VISAL=...` in the shells

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -201,7 +201,7 @@ export BROWSER="qutebrowser"
 export TERMINAL="alacritty -e"
 # changes the editor in the terminal, to edit long commands.
 export EDITOR='lvim'
-export VISAL="$EDITOR"
+export VISUAL="$EDITOR"
 set -o vi
 
 ### SET MANPAGER

--- a/.bashrc
+++ b/.bashrc
@@ -201,7 +201,7 @@ export BROWSER="qutebrowser"
 export TERMINAL="alacritty -e"
 # changes the editor in the terminal, to edit long commands.
 export EDITOR='lvim'
-export VISAL='lvim'
+export VISAL="$EDITOR"
 set -o vi
 
 ### SET MANPAGER

--- a/.config/nushell/env.nu
+++ b/.config/nushell/env.nu
@@ -76,7 +76,7 @@ let-env BROWSER = "qutebrowser"
 let-env TERMINAL = "alacritty -e"
 # changes the editor in the terminal, to edit long commands.
 let-env EDITOR = 'lvim'
-let-env VISAL = $env.EDITOR
+let-env VISUAL = $env.EDITOR
 
 ### SET MANPAGER
 ### Uncomment only one of these!

--- a/.config/nushell/env.nu
+++ b/.config/nushell/env.nu
@@ -76,7 +76,7 @@ let-env BROWSER = "qutebrowser"
 let-env TERMINAL = "alacritty -e"
 # changes the editor in the terminal, to edit long commands.
 let-env EDITOR = 'lvim'
-let-env VISAL = 'lvim'
+let-env VISAL = $env.EDITOR
 
 ### SET MANPAGER
 ### Uncomment only one of these!


### PR DESCRIPTION
This PR
- fixes the name of the `VISUAL` environment variable in both `nushell` and `bash`
- sets `VISUAL` to the `EDITOR`

now, one only needs to change `export EDITOR=...` in the `bashrc` and `let-env EDITOR = ...` in `config.nu` to change the editor system wise :+1: 