### PR TITLE
FEATURE: add a config `gitignore` and `spicy` config

### DIFF
--- a/.config/spicy/settings
+++ b/.config/spicy/settings
@@ -1,0 +1,10 @@
+[general]
+grab-keyboard=true
+grab-mouse=true
+scaling=true
+auto-clipboard=true
+sync-modifiers=true
+
+[ui]
+toolbar=true
+statusbar=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# hidden directories
+.cache/
+.cargo/
+.gnome/
+.local/
+.mozilla/
+.pki/
+.ssh/
+
+# regular directories
+documents/
+downloads/
+media/
+
+# hidden files
+.Xauthority
+.bash_history
+.fzf.bash
+.lesshst
+.lldb/lldb-widehistory
+.moc/equalizer
+.moc/last_directory
+.moc/softmixer
+.python_history
+.viminfo
+.wget-hsts
+
+
+# the config directories
+.config/discord/
+.config/libreoffice/
+.config/vim/plugged/
+
+# the config files
+.config/asciinema/install-id
+.config/dconf/user
+.config/gh/hosts.yml
+.config/kolourpaintrc
+.config/lazygit/state.yml
+.config/menus/applications-merged/xdg-desktop-menu-dummy.menu
+.config/mpd/database
+.config/mpd/pid
+.config/nushell/history.txt
+.config/nushell/lib/default_config.nu
+.config/okularrc
+.config/pulse/cookie
+.config/user-dirs.dirs
+.config/user-dirs.locale
+.config/vim/autoload/plug.vim

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,9 @@ media/
 
 
 # the config directories
+.config/chromium/
 .config/discord/
+.config/grip/cache*/
 .config/libreoffice/
 .config/vim/plugged/
 


### PR DESCRIPTION
This PR
- adds a basic config for `spice`, used to run VM with `qemu`
- this gave me the idea to not avoid all the untracked files, but rather to select which one are to be ignored or not

This PR should allow the `git status` to stay clean but a the same time to see new config files!