### PR TITLE
FEATURE: add `gpg` signature support to `git`

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -142,7 +142,7 @@
 [push]
 	autoSetupRemote = true
 	default = nothing
-	gpgsign = true
+	gpgsign = false
 [commit]
 	gpgsign = true
 [tag]

--- a/.config/git/config
+++ b/.config/git/config
@@ -142,3 +142,8 @@
 [push]
 	autoSetupRemote = true
 	default = nothing
+	gpgsign = true
+[commit]
+	gpgsign = true
+[tag]
+	gpgsign = true

--- a/.config/git/config
+++ b/.config/git/config
@@ -11,7 +11,7 @@
 
 [user]
   name = amtoine
-  email = 44101798+amtoine@users.noreply.github.com
+	email = stevan.antoine@gmail.com
 	signingkey = 7C5EE50BA27B86B7F9D5A7BA37AAE9B486CFF1AB
 [init]
   defaultBranch = main

--- a/.config/git/config
+++ b/.config/git/config
@@ -12,6 +12,7 @@
 [user]
   name = amtoine
   email = 44101798+amtoine@users.noreply.github.com
+	signingkey = 7C5EE50BA27B86B7F9D5A7BA37AAE9B486CFF1AB
 [init]
   defaultBranch = main
 

--- a/.config/qutebrowser/quickmarks
+++ b/.config/qutebrowser/quickmarks
@@ -183,3 +183,4 @@ tomb https://dyne.org/software/tomb/
 meson https://mesonbuild.com/index.html
 scons https://scons.org/
 spiral-rule https://c-faq.com/decl/spiral.anderson.html
+gh-commit-signature-verification https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification


### PR DESCRIPTION
In order to sign and verify commits and tags, this PR
- adds my real email address to email-verify commits
- adds my `gpg` public key to both the `git` config and my _GitHub_ account
- makes commits and tags `--signed` by default
- does NOT make pushes `--signed` by default as _GitHub_ does not support them for now
> this causes the following "fatal" error
> ```bash
> > git push --signed
> fatal: the receiving end does not support --signed push
> ```
- adds a `qutebrowser` quickmark to the _GitHub_ documentation about signing and verifying commits

:warning: this PR adds hardcoded personal values, i.e. `email = stevan.antoine@gmail.com` and `signingkey = 7C5EE50BA27B86B7F9D5A7BA37AAE9B486CFF1AB`...
this has been discussed a bit in https://github.com/goatfiles/dotfiles/discussions/20 and WILL be addressed in follow-up work :relieved: 