### PR TITLE
Quote source paths in reload_config keybinding

### DIFF
--- a/.config/nushell/lib/core/keybindings.nu
+++ b/.config/nushell/lib/core/keybindings.nu
@@ -36,7 +36,7 @@ export alias keybindings = [
     mode: [ emacs vi_insert vi_normal ]
     event: {
       send: executehostcommand,
-      cmd: $"source ($nu.env-path); source ($nu.config-path)"
+      cmd: $"source '($nu.env-path)'; source '($nu.config-path)'"
     }
   }
   {


### PR DESCRIPTION
I use macOS and installed nushell via brew. It installs configs in a path that contains a space (blurgh), so when I tried your `reload_config` keybinding as is, it fails. Per the [discussion on discord](https://discord.com/channels/601130461678272522/1093381138434764861/1093381138434764861), I tested surrounding the paths being fed to the source commands with "", then '', and while either of those work on a mac, someone mentioned that only '' works on Windows, so I added '' around the path expansions to handle the case where those paths might contain a space.